### PR TITLE
NFで釈放される共産主義革命家の政治力コストを75に設定

### DIFF
--- a/common/characters/GER.txt
+++ b/common/characters/GER.txt
@@ -1672,6 +1672,7 @@ characters={
 		advisor={
 			slot = political_advisor
 			idea_token = ernst_thalmann
+			cost = 75.000
 			allowed = {
 				original_tag = GER
 			}

--- a/common/characters/GER.txt
+++ b/common/characters/GER.txt
@@ -1813,6 +1813,7 @@ characters={
 		advisor={
 			slot = political_advisor
 			idea_token = karl_artelt
+			cost = 75.000
 			allowed = {
 				original_tag = GER
 			}


### PR DESCRIPTION
より容易に共産主義ツリーを進めると共に、他の閣僚の下位互換とならないようにするため。